### PR TITLE
url didn't work when hosted under an endpoint

### DIFF
--- a/web/src/connector.ts
+++ b/web/src/connector.ts
@@ -13,7 +13,7 @@ export async function get_next_item<T>(): Promise<T | null> {
     try {
       return await new Promise<T>((resolve, reject) => {
         $.ajax({
-          url: `/get-next-item`,
+          url: `get-next-item`,
           method: "POST",
           data: JSON.stringify({ "campaign_id": campaign_id, "user_id": user_id }),
           contentType: "application/json",
@@ -52,7 +52,7 @@ export async function log_response(payload: any, item_i: number | null): Promise
     try {
       await new Promise<void>((resolve, reject) => {
         $.ajax({
-          url: `/log-response`,
+          url: `log-response`,
           method: "POST",
           data: JSON.stringify({ "campaign_id": campaign_id, "user_id": user_id, "payload": payload, "item_i": item_i }),
           contentType: "application/json",
@@ -91,7 +91,7 @@ export async function get_i_item<T>(item_i: number | string): Promise<T | null> 
     try {
       return await new Promise<T>((resolve, reject) => {
         $.ajax({
-          url: `/get-i-item`,
+          url: `get-i-item`,
           method: "POST",
           data: JSON.stringify({ "campaign_id": campaign_id, "user_id": user_id, "item_i": item_i }),
           contentType: "application/json",

--- a/web/src/dashboard.ts
+++ b/web/src/dashboard.ts
@@ -33,7 +33,7 @@ function delta_to_human(delta: number): string {
 
 async function fetchAndRenderCampaign(campaign_id: string, token: string | null) {
     let x = await $.ajax({
-        url: `/dashboard-data`,
+        url: `dashboard-data`,
         method: "POST",
         data: JSON.stringify({ "campaign_id": campaign_id, "token": token }),
         contentType: "application/json",
@@ -200,7 +200,7 @@ async function fetchAndRenderCampaign(campaign_id: string, token: string | null)
         // Fetch results data
         try {
             const resultsData = await $.ajax({
-                url: `/dashboard-results`,
+                url: `dashboard-results`,
                 method: "POST",
                 data: JSON.stringify({ "campaign_id": campaign_id, "token": token }),
                 contentType: "application/json",
@@ -281,7 +281,7 @@ async function fetchAndRenderCampaign(campaign_id: string, token: string | null)
                 }
 
                 $.ajax({
-                    url: `/purge-campaign`,
+                    url: `purge-campaign`,
                     method: "POST",
                     data: JSON.stringify({ "campaign_id": campaign_id, "token": token }),
                     contentType: "application/json",
@@ -328,7 +328,7 @@ async function fetchAndRenderCampaign(campaign_id: string, token: string | null)
                 for (let user_id in data) {
                     resetPromises.push(
                         $.ajax({
-                            url: `/reset-task`,
+                            url: `reset-task`,
                             method: "POST",
                             data: JSON.stringify({ "campaign_id": campaign_id, "user_id": user_id, "token": token }),
                             contentType: "application/json",
@@ -360,7 +360,7 @@ async function fetchAndRenderCampaign(campaign_id: string, token: string | null)
                 return
             }
             $.ajax({
-                url: `/reset-task`,
+                url: `reset-task`,
                 method: "POST",
                 data: JSON.stringify({ "campaign_id": campaign_id, "user_id": user_id, "token": token }),
                 contentType: "application/json",
@@ -427,7 +427,7 @@ $("#campaign_file_input").on("change", async function (event: JQuery.ChangeEvent
         }
 
         const response = await $.ajax({
-            url: `/add-campaign`,
+            url: `add-campaign`,
             method: "POST",
             data: JSON.stringify({ campaign_data: campaignData, token_main: tokenMain }),
             contentType: "application/json",


### PR DESCRIPTION
spotted when:

```
pearmut run --url https://quest.ms.mff.cuni.cz/pearmut/jsalt --port 9002
```

then added campaing.json, then opened dashboard landing page. 

Error:
javascripts cause 404 because they tend to access `https://quest.ms.mff.cuni.cz/dashboard-data` and not `https://quest.ms.mff.cuni.cz/pearmut/jsalt/dashboard-data` .

Fix suggested by @zouharvi , then npm reinstall and tested that it works.