### PR TITLE
fix: fix dynamic selection not working due to missing score with custom sliders

### DIFF
--- a/build_hooks.py
+++ b/build_hooks.py
@@ -1,0 +1,54 @@
+"""Build hooks for integrating frontend build into Python package build process."""
+
+import subprocess
+import sys
+
+from setuptools.build_meta import build_editable as _build_editable
+from setuptools.build_meta import build_sdist as _build_sdist
+from setuptools.build_meta import build_wheel as _build_wheel
+
+
+def _build_frontend() -> None:
+    """Build frontend using npm. Fails if npm is missing or build fails."""
+    result = subprocess.run(
+        ["npm", "install", "--prefix", "web/"],
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(1)
+
+    result = subprocess.run(
+        ["npm", "run", "build", "--prefix", "web/"],
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(1)
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    """Build wheel. Builds frontend first."""
+    _build_frontend()
+    return _build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: dict | None = None,
+) -> str:
+    """Build source distribution. Builds frontend first."""
+    _build_frontend()
+    return _build_sdist(sdist_directory, config_settings)
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: dict | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    """Build editable wheel. Builds frontend first."""
+    _build_frontend()
+    return _build_editable(wheel_directory, config_settings, metadata_directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ packages = ["pearmut", "pearmut.web"]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "build_hooks"
+backend-path = ["."]
 
 [tool.setuptools.package-data]
 "pearmut" = ["static/**"]

--- a/server/assignment.py
+++ b/server/assignment.py
@@ -37,6 +37,7 @@ CAMPAIGN_INFO_PUBLIC = {
     "special_tokens",
     "assignment",
     "dynamic_models",
+    "dynamic_slider",
     "docs_per_user",
 }
 
@@ -663,13 +664,21 @@ def get_next_item_dynamic(
         annotations = get_active_db_log(campaign_id)
 
         model_scores = collections.defaultdict(list)
+        dynamic_slider = campaign_data["info"].get("dynamic_slider")
+        
         for annotation_line in annotations:
             for annotation_item in annotation_line.get("annotation", {}):
                 if annotation_item is None:  # skippable items have no annotation
                     continue
                 for model in annotation_item:
-                    if "score" in annotation_item[model] and annotation_item[model]["score"] is not None:
-                        model_scores[model].append(annotation_item[model]["score"])
+                    # Extract score from dynamic_slider if configured, otherwise from score field
+                    if dynamic_slider and "sliders" in annotation_item[model]:
+                        score_val = annotation_item[model].get("sliders", {}).get(dynamic_slider)
+                    else:
+                        score_val = annotation_item[model].get("score")
+                    
+                    if score_val is not None:
+                        model_scores[model].append(score_val)
 
         # Calculate average scores
         model_avg_scores = {

--- a/server/cli.py
+++ b/server/cli.py
@@ -528,6 +528,22 @@ def _add_single_campaign(campaign_data, overwrite, url):
                 "Each slider must be a dict with 'name', 'min', 'max', and 'step' keys, where min/max/step are numeric, min <= max, and step > 0"
             )
 
+    # Validate dynamic_slider configuration if present
+    if "dynamic_slider" in campaign_data["info"]:
+        if assignment != "dynamic":
+            raise ValueError(
+                "'dynamic_slider' can only be used with 'dynamic' assignment type"
+            )
+        if "sliders" not in campaign_data["info"]:
+            raise ValueError(
+                "'dynamic_slider' requires 'sliders' to be defined in campaign info"
+            )
+        slider_names = {s["name"] for s in campaign_data["info"]["sliders"]}
+        if campaign_data["info"]["dynamic_slider"] not in slider_names:
+            raise ValueError(
+                f"'dynamic_slider' value '{campaign_data['info']['dynamic_slider']}' must be one of: {sorted(slider_names)}"
+            )
+
     # Remove output file when overwriting (after all validations pass)
     if overwrite and campaign_data["campaign_id"] in progress_data:
         output_file = f"{ROOT}/data/annotations/{campaign_data['campaign_id']}.jsonl"

--- a/server/tests/test_assignment.py
+++ b/server/tests/test_assignment.py
@@ -1488,3 +1488,132 @@ class TestDynamic:
         assert '"status":"ok"' in content
         # Should return an item
         assert '"item_i"' in content
+
+    def test_dynamic_slider_uses_slider_value_for_ranking(self):
+        """Test that dynamic assignment uses dynamic_slider value for model ranking."""
+        _clear_test_logs()
+        campaigns_data = {
+            "campaign1": {
+                "info": {
+                    "assignment": "dynamic",
+                    "dynamic_coldstart": 1,
+                    "dynamic_models": 1,
+                    "dynamic_slider": "Fluency",
+                    "sliders": [
+                        {"name": "Fluency", "min": 0, "max": 100, "step": 1},
+                        {"name": "Adequacy", "min": 0, "max": 100, "step": 1}
+                    ]
+                },
+                "data": [
+                    [{"src": "a", "tgt": {"model1": "b", "model2": "c"}}],
+                    [{"src": "d", "tgt": {"model1": "e", "model2": "f"}}],
+                    [{"src": "g", "tgt": {"model1": "h", "model2": "i"}}],
+                ]
+            }
+        }
+        progress_data = {
+            "campaign1": {
+                "user1": {
+                    "progress": [
+                        {"model1": "completed", "model2": "completed"},
+                        {"model1": None, "model2": None},
+                        {"model1": None, "model2": None},
+                    ],
+                    "progress_welcome": [],
+                    "time": 0,
+                    "token_correct": "abc",
+                    "token_incorrect": "xyz",
+                }
+            }
+        }
+        
+        # Save annotation with slider values
+        # model1 has high Fluency (90), model2 has low Fluency (30)
+        save_db_payload("campaign1", {
+            "user_id": "user1",
+            "item_i": 0,
+            "annotation": [
+                {
+                    "model1": {
+                        "score": 90,  # This should be ignored when dynamic_slider is set
+                        "sliders": {"Fluency": 90, "Adequacy": 50},
+                        "error_spans": []
+                    },
+                    "model2": {
+                        "score": 30,  # This should be ignored when dynamic_slider is set
+                        "sliders": {"Fluency": 30, "Adequacy": 80},
+                        "error_spans": []
+                    }
+                }
+            ]
+        })
+        
+        # Get next item - should prefer model2 since it has lower Fluency score
+        response = get_next_item("campaign1", "user1", campaigns_data, progress_data)
+        assert response.status_code == 200
+        import json
+        data = json.loads(response.body.decode())
+        # Should return item 1 or 2 (both incomplete)
+        assert data["info"]["item_i"] in [1, 2]
+
+    def test_dynamic_slider_falls_back_to_score_when_not_set(self):
+        """Test that dynamic assignment uses score field when dynamic_slider is not set."""
+        _clear_test_logs()
+        campaigns_data = {
+            "campaign1": {
+                "info": {
+                    "assignment": "dynamic",
+                    "dynamic_coldstart": 1,
+                    "dynamic_models": 1,
+                    "sliders": [
+                        {"name": "Fluency", "min": 0, "max": 100, "step": 1}
+                    ]
+                },
+                "data": [
+                    [{"src": "a", "tgt": {"model1": "b", "model2": "c"}}],
+                    [{"src": "d", "tgt": {"model1": "e", "model2": "f"}}],
+                ]
+            }
+        }
+        progress_data = {
+            "campaign1": {
+                "user1": {
+                    "progress": [
+                        {"model1": "completed", "model2": "completed"},
+                        {"model1": None, "model2": None},
+                    ],
+                    "progress_welcome": [],
+                    "time": 0,
+                    "token_correct": "abc",
+                    "token_incorrect": "xyz",
+                }
+            }
+        }
+        
+        # Save annotation with only score field (no dynamic_slider set)
+        save_db_payload("campaign1", {
+            "user_id": "user1",
+            "item_i": 0,
+            "annotation": [
+                {
+                    "model1": {
+                        "score": 90,
+                        "sliders": {"Fluency": 50},  # This should be ignored
+                        "error_spans": []
+                    },
+                    "model2": {
+                        "score": 30,
+                        "sliders": {"Fluency": 90},  # This should be ignored
+                        "error_spans": []
+                    }
+                }
+            ]
+        })
+        
+        # Get next item - should use score field (not sliders)
+        response = get_next_item("campaign1", "user1", campaigns_data, progress_data)
+        assert response.status_code == 200
+        import json
+        data = json.loads(response.body.decode())
+        # Should return item 1
+        assert data["info"]["item_i"] == 1

--- a/server/tests/test_validation.py
+++ b/server/tests/test_validation.py
@@ -353,3 +353,112 @@ class TestItemValidation:
 
         # Should not raise - custom slider validation is valid
         _add_single_campaign(campaign_data, True, "http://localhost:8001")
+
+    def test_dynamic_slider_valid_configuration(self):
+        """Test that valid dynamic_slider configuration is accepted."""
+        from pearmut.cli import _add_single_campaign
+
+        campaign_data = {
+            "campaign_id": "test_dynamic_slider_valid",
+            "info": {
+                "assignment": "dynamic",
+                "protocol": "ESA",
+                "users": 2,
+                "dynamic_slider": "Fluency",
+                "sliders": [
+                    {"name": "Fluency", "min": 0, "max": 100, "step": 1},
+                    {"name": "Adequacy", "min": 0, "max": 100, "step": 1}
+                ]
+            },
+            "data": [
+                [
+                    {"src": "hello", "tgt": {"A": "hola", "B": "ola"}},
+                ],
+                [
+                    {"src": "world", "tgt": {"A": "mundo", "B": "munda"}},
+                ]
+            ]
+        }
+
+        # Should not raise - valid dynamic_slider configuration
+        _add_single_campaign(campaign_data, True, "http://localhost:8001")
+
+    def test_dynamic_slider_requires_sliders(self):
+        """Test that dynamic_slider requires sliders to be defined."""
+        from pearmut.cli import _add_single_campaign
+        import pytest
+
+        campaign_data = {
+            "campaign_id": "test_dynamic_slider_no_sliders",
+            "info": {
+                "assignment": "dynamic",
+                "protocol": "ESA",
+                "users": 2,
+                "dynamic_slider": "Fluency"
+            },
+            "data": [
+                [
+                    {"src": "hello", "tgt": {"A": "hola", "B": "ola"}},
+                ]
+            ]
+        }
+
+        # Should raise - dynamic_slider requires sliders
+        with pytest.raises(ValueError, match="'dynamic_slider' requires 'sliders'"):
+            _add_single_campaign(campaign_data, True, "http://localhost:8001")
+
+    def test_dynamic_slider_requires_dynamic_assignment(self):
+        """Test that dynamic_slider only works with dynamic assignment."""
+        from pearmut.cli import _add_single_campaign
+        import pytest
+
+        campaign_data = {
+            "campaign_id": "test_dynamic_slider_task_based",
+            "info": {
+                "assignment": "task-based",
+                "protocol": "ESA",
+                "dynamic_slider": "Fluency",
+                "sliders": [
+                    {"name": "Fluency", "min": 0, "max": 100, "step": 1}
+                ]
+            },
+            "data": [
+                [
+                    [
+                        {"src": "hello", "tgt": {"A": "hola"}},
+                    ]
+                ]
+            ]
+        }
+
+        # Should raise - dynamic_slider only for dynamic assignment
+        with pytest.raises(ValueError, match="'dynamic_slider' can only be used with 'dynamic' assignment"):
+            _add_single_campaign(campaign_data, True, "http://localhost:8001")
+
+    def test_dynamic_slider_must_exist(self):
+        """Test that dynamic_slider value must match a defined slider."""
+        from pearmut.cli import _add_single_campaign
+        import pytest
+
+        campaign_data = {
+            "campaign_id": "test_dynamic_slider_nonexistent",
+            "info": {
+                "assignment": "dynamic",
+                "protocol": "ESA",
+                "users": 2,
+                "dynamic_slider": "NonExistent",
+                "sliders": [
+                    {"name": "Fluency", "min": 0, "max": 100, "step": 1},
+                    {"name": "Adequacy", "min": 0, "max": 100, "step": 1}
+                ]
+            },
+            "data": [
+                [
+                    {"src": "hello", "tgt": {"A": "hola", "B": "ola"}},
+                ]
+            ]
+        }
+
+        # Should raise - dynamic_slider value doesn't exist
+        with pytest.raises(ValueError, match="'dynamic_slider' value 'NonExistent' must be one of"):
+            _add_single_campaign(campaign_data, True, "http://localhost:8001")

--- a/web/src/annotate.ts
+++ b/web/src/annotate.ts
@@ -752,6 +752,10 @@ function setupCandidateInteractions(
                 let val = parseInt((<HTMLInputElement>this).value)
                 label.text(`${val}/${sliderMax}`)
                 state.response_log[item_i][model].sliders![sliderName] = val
+                // Sync with score field if this is the dynamic_slider
+                if (response.info.dynamic_slider === sliderName) {
+                    state.response_log[item_i][model].score = val
+                }
             })
             // special handler if we ever go back to the original position
             slider.on("mouseup", function () {
@@ -766,6 +770,10 @@ function setupCandidateInteractions(
 
                 // Store in sliders field
                 state.response_log[item_i][model].sliders![sliderName] = val
+                // Sync with score field if this is the dynamic_slider
+                if (response.info.dynamic_slider === sliderName) {
+                    state.response_log[item_i][model].score = val
+                }
                 state.action_log.push({ "time": Date.now() / 1000, "action": sliderName, "index": item_i, "model": model, "value": val })
                 state.has_unsaved_work = true
                 check_unlock()
@@ -784,6 +792,10 @@ function setupCandidateInteractions(
                 slider.val(existingScore)
                 label.text(`${existingScore}/${sliderMax}`)
                 state.response_log[item_i][model].sliders![sliderName] = existingScore
+                // Sync with score field if this is the dynamic_slider
+                if (response.info.dynamic_slider === sliderName) {
+                    state.response_log[item_i][model].score = existingScore
+                }
             }
         }
     } else if (!hasNoSliders) {

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -627,6 +627,7 @@ export type ProtocolInfo = {
     special_tokens?: string[],  // Optional custom special tokens
     assignment?: string,
     dynamic_models?: number,
+    dynamic_slider?: string,  // Optional slider name to use for dynamic ranking
     docs_per_user?: number,
 }
 


### PR DESCRIPTION
Added config `dynamic_slider` that names the slider used for dynamic selection and scoring.
See #339. 

This commit/PR was created with the help of an AI agent. Since I don't have profound insights into the project, this PR should be thoroughly reviewed before accepting. Thus, I mark this only as a draft.